### PR TITLE
Fix HTML runtime preview hangs

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ import time
 import uuid
 from pathlib import Path
 from typing import Dict, Any, Optional
+from urllib.parse import quote
 
 from flask import Flask, send_from_directory, send_file, request, jsonify
 from flask_socketio import SocketIO, emit, join_room, leave_room
@@ -300,8 +301,9 @@ def _cleanup_expired_html_runtime_sessions(force: bool = False) -> None:
         for runtime_id, session in list(_html_runtime_sessions.items()):
             expires_at = float(session.get("expires_at", 0))
             if force or expires_at <= now:
-                runtime_dir = Path(session.get("runtime_dir", ""))
-                to_remove.append((runtime_id, runtime_dir))
+                runtime_dir = session.get("runtime_dir")
+                if runtime_dir:
+                    to_remove.append((runtime_id, Path(runtime_dir)))
                 _html_runtime_sessions.pop(runtime_id, None)
     for _, runtime_dir in to_remove:
         _delete_path_quietly(runtime_dir)
@@ -311,7 +313,7 @@ def _remove_html_runtime_session(runtime_id: str) -> None:
     runtime_dir = None
     with _html_runtime_lock:
         session = _html_runtime_sessions.pop(runtime_id, None)
-        if session:
+        if session and session.get("runtime_dir"):
             runtime_dir = Path(session.get("runtime_dir", ""))
     if runtime_dir:
         _delete_path_quietly(runtime_dir)
@@ -3054,6 +3056,150 @@ def root():
     return send_from_directory(BASE_DIR, "index.html")
 
 
+def _html_runtime_popup_shell(channel_id: str) -> str:
+    channel_json = json.dumps(channel_id)
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>EagleIDE HTML WebView</title>
+  <style>
+    body{{margin:0;font-family:Inter,Arial,sans-serif;background:#121212;color:#eaeaea;display:flex;flex-direction:column;height:100vh}}
+    .hdr{{display:flex;justify-content:space-between;align-items:center;padding:10px 14px;background:#1f1f1f;border-bottom:1px solid #333;gap:12px}}
+    .hdr strong{{font-size:14px}}
+    .hdr button{{border:0;border-radius:8px;padding:6px 10px;background:#c62828;color:#fff;cursor:pointer;font-weight:700}}
+    .runtime-msg{{font-size:12px;opacity:.85;margin-top:2px}}
+    .empty{{flex:1;display:grid;place-items:center;background:#181818;color:#aaa;text-align:center;padding:24px}}
+    #runtimeFrame{{flex:1;width:100%;border:0;background:#fff;display:none}}
+  </style>
+</head>
+<body>
+  <div class="hdr">
+    <div><strong id="runtimeTitle">HTML WebView</strong><div class="runtime-msg" id="runtimeMsg">Preparing preview...</div></div>
+    <button id="runtimeExitBtn" type="button">Exit X</button>
+  </div>
+  <div class="empty" id="runtimeEmpty">Preparing HTML preview...</div>
+  <iframe id="runtimeFrame" sandbox="allow-scripts"></iframe>
+  <script>
+    (function(){{
+      const channelId = {channel_json};
+      const channelName = "eagle-html-runtime-" + channelId;
+      const frame = document.getElementById("runtimeFrame");
+      const empty = document.getElementById("runtimeEmpty");
+      const msgEl = document.getElementById("runtimeMsg");
+      const titleEl = document.getElementById("runtimeTitle");
+      let runtimeId = "";
+      let timeoutHandle = null;
+      let stopped = false;
+      let channel = null;
+
+      const setMsg = (text) => {{ if (msgEl) msgEl.textContent = text || ""; }};
+      const send = (payload) => {{
+        try {{ if (channel) channel.postMessage(payload); }} catch {{}}
+      }};
+      const sendLog = (level, message) => {{
+        send({{ type: "eagle-html-runtime-log", level, message }});
+      }};
+      const cleanupRuntime = () => {{
+        if (!runtimeId) return;
+        try {{
+          navigator.sendBeacon("/api/html-runtime/cleanup", new Blob([JSON.stringify({{ runtime_id: runtimeId }})], {{ type: "application/json" }}));
+        }} catch {{
+          fetch("/api/html-runtime/cleanup", {{ method: "POST", headers: {{ "Content-Type": "application/json" }}, body: JSON.stringify({{ runtime_id: runtimeId }}) }}).catch(() => {{}});
+        }}
+      }};
+      const terminate = (reason, cleanup = true) => {{
+        if (stopped) return;
+        stopped = true;
+        if (timeoutHandle) clearTimeout(timeoutHandle);
+        frame.src = "about:blank";
+        frame.style.display = "none";
+        empty.style.display = "grid";
+        empty.textContent = reason || "Execution stopped.";
+        setMsg(reason || "Execution stopped.");
+        sendLog("warn", reason || "Execution stopped.");
+        if (cleanup) cleanupRuntime();
+      }};
+      const loadRuntime = (runtime) => {{
+        if (!runtime || !runtime.runtime_id || !runtime.view_url) {{
+          terminate("Invalid HTML runtime response.", false);
+          return;
+        }}
+        stopped = false;
+        runtimeId = String(runtime.runtime_id);
+        const timeoutSeconds = Number(runtime.timeout_seconds || 30);
+        const sandboxFlags = ["allow-scripts"];
+        if (runtime.allow_popups) sandboxFlags.push("allow-popups");
+        frame.setAttribute("sandbox", sandboxFlags.join(" "));
+        if (titleEl) titleEl.textContent = runtime.title || "HTML WebView";
+        empty.style.display = "none";
+        frame.style.display = "block";
+        setMsg("Running...");
+        timeoutHandle = setTimeout(() => terminate("Execution time limit reached."), Math.max(1000, Math.floor(timeoutSeconds * 1000)));
+        frame.src = runtime.view_url;
+      }};
+
+      if ("BroadcastChannel" in window) {{
+        channel = new BroadcastChannel(channelName);
+        channel.onmessage = (event) => {{
+          const data = event.data || {{}};
+          if (data.type === "load") {{
+            loadRuntime(data.runtime || {{}});
+          }} else if (data.type === "stop") {{
+            terminate(data.reason || "Execution stopped.");
+          }} else if (data.type === "error") {{
+            terminate(data.message || "Could not start HTML runtime.", false);
+          }}
+        }};
+        send({{ type: "ready" }});
+      }} else {{
+        empty.textContent = "This browser does not support isolated HTML previews.";
+        setMsg("BroadcastChannel unavailable.");
+      }}
+
+      window.addEventListener("message", (event) => {{
+        const data = event.data || {{}};
+        if (!data.__eagleHtmlRuntime) return;
+        if (data.type === "limit") {{
+          terminate(data.message || "Execution time limit reached.");
+        }} else if (data.type === "error") {{
+          sendLog("error", data.message || "JavaScript runtime error");
+        }} else if (data.type === "console" && data.level === "error") {{
+          sendLog("error", data.message || "console.error");
+        }} else if (data.type === "status") {{
+          sendLog("warn", data.message || "Runtime status");
+        }}
+      }});
+      frame.addEventListener("load", () => {{
+        if (!stopped && runtimeId) setMsg("Running...");
+      }});
+      frame.addEventListener("error", () => terminate("Execution stopped due to iframe load error."));
+      document.getElementById("runtimeExitBtn").addEventListener("click", () => {{
+        cleanupRuntime();
+        window.close();
+      }});
+      window.addEventListener("beforeunload", () => {{
+        cleanupRuntime();
+        send({{ type: "closed", runtime_id: runtimeId }});
+        try {{ if (channel) channel.close(); }} catch {{}}
+      }});
+    }})();
+  </script>
+</body>
+</html>"""
+
+
+@app.get("/api/html-runtime/popup/<channel_id>")
+def html_runtime_popup(channel_id: str):
+    if not re.fullmatch(r"[A-Za-z0-9_-]{8,120}", channel_id or ""):
+        return jsonify(ok=False, error="Invalid runtime channel"), 400
+    response = app.response_class(_html_runtime_popup_shell(channel_id), mimetype="text/html")
+    response.headers["Cross-Origin-Opener-Policy"] = "same-origin"
+    response.headers["Referrer-Policy"] = "no-referrer"
+    return response
+
+
 def _html_runtime_js_bridge(cfg: Dict[str, Any]) -> str:
     bridge_cfg = {
         "allow_external_internet": _cfg_bool(cfg, "html_runtime_allow_external_internet", False),
@@ -3261,33 +3407,24 @@ def start_html_runtime():
         return jsonify(ok=False, error="Only .html files can use HTML runtime"), 400
 
     runtime_id = uuid.uuid4().hex
-    runtime_dir = SANDBOX_DIR / f"html_runtime_{runtime_id}"
     source_root = user_dir.resolve()
     entry_path = str(target.resolve().relative_to(source_root)).replace("\\", "/")
-    runtime_resolved = runtime_dir.resolve()
-    sandbox_root = SANDBOX_DIR.resolve()
-    if os.path.commonpath([str(runtime_resolved), str(sandbox_root)]) != str(sandbox_root):
-        return jsonify(ok=False, error="Invalid runtime directory"), 500
-    try:
-        shutil.copytree(source_root, runtime_resolved, dirs_exist_ok=True, symlinks=False, ignore_dangling_symlinks=True)
-    except Exception:
-        _delete_path_quietly(runtime_dir)
-        return jsonify(ok=False, error="Could not prepare HTML runtime environment"), 500
 
     timeout_seconds = _cfg_int(cfg, "html_runtime_timeout_seconds", HTML_RUNTIME_DEFAULT_TIMEOUT, 1, 600)
     session_ttl_seconds = timeout_seconds + 120
     _cleanup_expired_html_runtime_sessions()
     with _html_runtime_lock:
         _html_runtime_sessions[runtime_id] = {
-            "runtime_dir": str(runtime_resolved),
+            "runtime_root": str(source_root),
             "entry_file": entry_path,
+            "owner_email": user.get("email", ""),
             "expires_at": time.time() + session_ttl_seconds,
         }
 
     return jsonify(
         ok=True,
         runtime_id=runtime_id,
-        view_url=f"/api/html-runtime/view/{runtime_id}/{entry_path}",
+        view_url=f"/api/html-runtime/view/{runtime_id}/{quote(entry_path, safe='/')}",
         timeout_seconds=timeout_seconds,
         allow_external_internet=_cfg_bool(cfg, "html_runtime_allow_external_internet", False),
         allow_popups=_cfg_bool(cfg, "html_runtime_allow_popups", False),
@@ -3316,7 +3453,7 @@ def view_html_runtime_asset(runtime_id: str, asset_path: str):
     if not session:
         return jsonify(ok=False, error="Runtime session not found or expired"), 404
 
-    runtime_root = Path(session.get("runtime_dir", ""))
+    runtime_root = Path(session.get("runtime_root") or session.get("runtime_dir", ""))
     target = _validate_user_path(runtime_root, asset_path)
     if not target or not target.exists() or not target.is_file():
         return jsonify(ok=False, error="Runtime asset not found"), 404

--- a/static/js/app-core.js
+++ b/static/js/app-core.js
@@ -1036,7 +1036,15 @@ const INPUT_TOKEN = "[[_IDE_INPUT_]]";
       const channel = new BroadcastChannel(`eagle-html-runtime-${channelId}`);
       channel.onmessage = (event) => {
         const payload = event.data || {};
-        if (payload.type === 'eagle-html-runtime-log') {
+        if (payload.type === 'ready') {
+          if (htmlRuntimeWindow) {
+            htmlRuntimeWindow.ready = true;
+            if (htmlRuntimeWindow.pendingRuntime) {
+              htmlRuntimeWindow.channel.postMessage(htmlRuntimeWindow.pendingRuntime);
+              htmlRuntimeWindow.pendingRuntime = null;
+            }
+          }
+        } else if (payload.type === 'eagle-html-runtime-log') {
           appendHtmlRuntimeLog(payload);
         } else if (payload.type === 'closed') {
           const closedRuntimeId = String(payload.runtime_id || '');
@@ -1054,7 +1062,7 @@ const INPUT_TOKEN = "[[_IDE_INPUT_]]";
         setRunButtonState(false);
         return false;
       }
-      htmlRuntimeWindow = { popup, channel, channelId };
+      htmlRuntimeWindow = { popup, channel, channelId, ready: false, pendingRuntime: null };
       appendOut('[HTML Runtime] Preparing WebView...\n');
       return true;
     }
@@ -1075,7 +1083,7 @@ const INPUT_TOKEN = "[[_IDE_INPUT_]]";
         setRunButtonState(false);
         cleanupHtmlRuntimeSession(runtimeData.runtime_id);
       }, Math.max(1000, Math.floor((timeoutSeconds + 5) * 1000)));
-      notifyHtmlRuntimePopup({
+      const loadMessage = {
         type: 'load',
         runtime: {
           runtime_id: runtimeData.runtime_id,
@@ -1084,7 +1092,12 @@ const INPUT_TOKEN = "[[_IDE_INPUT_]]";
           allow_popups: !!runtimeData.allow_popups,
           title
         }
-      });
+      };
+      if (htmlRuntimeWindow?.ready) {
+        notifyHtmlRuntimePopup(loadMessage);
+      } else if (htmlRuntimeWindow) {
+        htmlRuntimeWindow.pendingRuntime = loadMessage;
+      }
       appendOut('[HTML Runtime] WebView opened.\n');
     }
 

--- a/static/js/app-core.js
+++ b/static/js/app-core.js
@@ -953,6 +953,29 @@ const INPUT_TOKEN = "[[_IDE_INPUT_]]";
       return lower.endsWith('.html') || lower.endsWith('.htm');
     }
 
+    function makeHtmlRuntimeChannelId() {
+      if (window.crypto?.randomUUID) return window.crypto.randomUUID().replace(/[^A-Za-z0-9_-]/g, '');
+      return `rt${Date.now()}${Math.random().toString(36).slice(2)}`.replace(/[^A-Za-z0-9_-]/g, '');
+    }
+
+    function appendHtmlRuntimeLog(payload) {
+      const lvl = String(payload.level || 'info').toUpperCase();
+      const msg = String(payload.message || '').trim();
+      if (!msg) return;
+      appendOut(`[HTML ${lvl}] ${msg}\n`);
+    }
+
+    function teardownHtmlRuntimeBroadcast() {
+      if (htmlRuntimeCloseMonitor) {
+        clearTimeout(htmlRuntimeCloseMonitor);
+        htmlRuntimeCloseMonitor = null;
+      }
+      try {
+        if (htmlRuntimeWindow?.channel) htmlRuntimeWindow.channel.close();
+      } catch {}
+      if (htmlRuntimeWindow) htmlRuntimeWindow.channel = null;
+    }
+
     async function cleanupHtmlRuntimeSession(runtimeId = htmlRuntimeId) {
       const rid = String(runtimeId || '').trim();
       if (!rid) return;
@@ -966,18 +989,25 @@ const INPUT_TOKEN = "[[_IDE_INPUT_]]";
       if (rid === htmlRuntimeId) htmlRuntimeId = '';
     }
 
-    function closeHtmlRuntimeWindow() {
-      if (htmlRuntimeCloseMonitor) {
-        clearInterval(htmlRuntimeCloseMonitor);
-        htmlRuntimeCloseMonitor = null;
-      }
+    function notifyHtmlRuntimePopup(payload) {
       try {
-        if (htmlRuntimeWindow && !htmlRuntimeWindow.closed) {
+        htmlRuntimeWindow?.channel?.postMessage(payload);
+      } catch {}
+    }
+
+    function closeHtmlRuntimeWindow() {
+      const runtimeId = htmlRuntimeId;
+      notifyHtmlRuntimePopup({ type: 'stop', reason: 'Execution stopped.' });
+      try {
+        if (htmlRuntimeWindow?.popup && !htmlRuntimeWindow.popup.closed) {
+          htmlRuntimeWindow.popup.close();
+        } else if (htmlRuntimeWindow && !htmlRuntimeWindow.closed) {
           htmlRuntimeWindow.close();
         }
       } catch {}
+      teardownHtmlRuntimeBroadcast();
       htmlRuntimeWindow = null;
-      cleanupHtmlRuntimeSession();
+      cleanupHtmlRuntimeSession(runtimeId);
     }
 
     function setRunButtonState(running) {
@@ -996,109 +1026,65 @@ const INPUT_TOKEN = "[[_IDE_INPUT_]]";
       setRunButtonState(false);
     }
 
+    function openHtmlRuntimePopupShell() {
+      closeHtmlRuntimeWindow();
+      if (!('BroadcastChannel' in window)) {
+        appendOut('[HTML Runtime] This browser does not support isolated HTML previews.\n');
+        return false;
+      }
+      const channelId = makeHtmlRuntimeChannelId();
+      const channel = new BroadcastChannel(`eagle-html-runtime-${channelId}`);
+      channel.onmessage = (event) => {
+        const payload = event.data || {};
+        if (payload.type === 'eagle-html-runtime-log') {
+          appendHtmlRuntimeLog(payload);
+        } else if (payload.type === 'closed') {
+          const closedRuntimeId = String(payload.runtime_id || '');
+          if (closedRuntimeId && closedRuntimeId === htmlRuntimeId) cleanupHtmlRuntimeSession(closedRuntimeId);
+          teardownHtmlRuntimeBroadcast();
+          htmlRuntimeWindow = null;
+          setRunButtonState(false);
+        }
+      };
+      htmlRuntimeId = '';
+      const popup = window.open(`/api/html-runtime/popup/${encodeURIComponent(channelId)}`, `eagle-html-runtime-${channelId}`, 'popup=yes,width=1100,height=760');
+      if (!popup) {
+        appendOut('[HTML Runtime] Popup blocked by browser.\n');
+        try { channel.close(); } catch {}
+        setRunButtonState(false);
+        return false;
+      }
+      htmlRuntimeWindow = { popup, channel, channelId };
+      appendOut('[HTML Runtime] Preparing WebView...\n');
+      return true;
+    }
+
     function openHtmlRuntimePopup(runtimeData) {
       if (!runtimeData?.runtime_id || !runtimeData?.view_url) {
         appendOut('[HTML Runtime] Invalid runtime response\n');
+        notifyHtmlRuntimePopup({ type: 'error', message: 'Invalid runtime response.' });
         setRunButtonState(false);
         return;
       }
 
-      closeHtmlRuntimeWindow();
       htmlRuntimeId = runtimeData.runtime_id;
-      const popup = window.open('', `eagle-html-runtime-${runtimeData.runtime_id}`, 'popup=yes,width=1100,height=760');
-      if (!popup) {
-        appendOut('[HTML Runtime] Popup blocked by browser.\n');
-        cleanupHtmlRuntimeSession(runtimeData.runtime_id);
-        setRunButtonState(false);
-        return;
-      }
-      htmlRuntimeWindow = popup;
-      if (htmlRuntimeCloseMonitor) clearInterval(htmlRuntimeCloseMonitor);
-      htmlRuntimeCloseMonitor = setInterval(() => {
-        if (!htmlRuntimeWindow || htmlRuntimeWindow.closed) {
-          clearInterval(htmlRuntimeCloseMonitor);
-          htmlRuntimeCloseMonitor = null;
-          htmlRuntimeWindow = null;
-          cleanupHtmlRuntimeSession();
-          setRunButtonState(false);
-        }
-      }, 400);
-
       const timeoutSeconds = Number(runtimeData.timeout_seconds || 30);
-      const allowPopups = !!runtimeData.allow_popups;
       const title = `HTML WebView • ${currentOpenFile?.name || 'index.html'}`;
-      const iframeSandbox = ['allow-scripts', 'allow-same-origin'];
-      if (allowPopups) iframeSandbox.push('allow-popups');
-      const popupDoc = popup.document;
-      popupDoc.open();
-      popupDoc.write(`<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>${title.replace(/</g, '&lt;')}</title>
-  <style>
-    body{margin:0;font-family:Inter,Arial,sans-serif;background:#121212;color:#eaeaea;display:flex;flex-direction:column;height:100vh}
-    .hdr{display:flex;justify-content:space-between;align-items:center;padding:10px 14px;background:#1f1f1f;border-bottom:1px solid #333}
-    .hdr strong{font-size:14px}
-    .hdr button{border:0;border-radius:8px;padding:6px 10px;background:#c62828;color:#fff;cursor:pointer;font-weight:700}
-    .runtime-msg{font-size:12px;opacity:.85}
-    #runtimeFrame{flex:1;width:100%;border:0;background:#fff}
-  </style>
-</head>
-<body>
-  <div class="hdr">
-    <div><strong>${title.replace(/</g, '&lt;')}</strong><div class="runtime-msg" id="runtimeMsg">Running...</div></div>
-    <button id="runtimeExitBtn">Exit ✕</button>
-  </div>
-  <iframe id="runtimeFrame" sandbox="${iframeSandbox.join(' ')}" src="${runtimeData.view_url}"></iframe>
-  <script>
-    const runtimeId = ${JSON.stringify(runtimeData.runtime_id)};
-    const timeoutMs = ${Math.max(1000, Math.floor(timeoutSeconds * 1000))};
-    let stopped = false;
-    const frame = document.getElementById('runtimeFrame');
-    const msgEl = document.getElementById('runtimeMsg');
-    const sendToOpener = (payload) => { try { window.opener && window.opener.postMessage(payload, '*'); } catch {} };
-    const setMsg = (text) => { if (msgEl) msgEl.textContent = text; };
-    const cleanupRuntime = () => {
-      try {
-        navigator.sendBeacon('/api/html-runtime/cleanup', new Blob([JSON.stringify({ runtime_id: runtimeId })], { type: 'application/json' }));
-      } catch {
-        fetch('/api/html-runtime/cleanup', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ runtime_id: runtimeId }) }).catch(() => {});
-      }
-    };
-    const terminate = (reason) => {
-      if (stopped) return;
-      stopped = true;
-      frame.src = 'about:blank';
-      setMsg(reason || 'Execution stopped.');
-      sendToOpener({ type:'eagle-html-runtime-log', level:'warn', message: reason || 'Execution stopped.' });
-    };
-    document.getElementById('runtimeExitBtn').addEventListener('click', () => window.close());
-    window.addEventListener('beforeunload', cleanupRuntime);
-    const timeoutHandle = setTimeout(() => terminate('Execution time limit reached.'), timeoutMs);
-    window.addEventListener('message', (event) => {
-      const data = event.data || {};
-      if (!data.__eagleHtmlRuntime) return;
-      if (data.type === 'limit') {
-        terminate('Execution time limit reached.');
-      } else if (data.type === 'error') {
-        const details = data.message || 'JavaScript runtime error';
-        sendToOpener({ type:'eagle-html-runtime-log', level:'error', message: details });
-      } else if (data.type === 'console' && data.level === 'error') {
-        sendToOpener({ type:'eagle-html-runtime-log', level:'error', message: data.message || 'console.error' });
-      } else if (data.type === 'status') {
-        sendToOpener({ type:'eagle-html-runtime-log', level:'warn', message: data.message || 'Runtime status' });
-      }
-    });
-    frame.addEventListener('load', () => {
-      if (!stopped) setMsg('Running...');
-    });
-    frame.addEventListener('error', () => terminate('Execution stopped due to iframe load error.'));
-    window.addEventListener('unload', () => clearTimeout(timeoutHandle));
-  <\/script>
-</body>
-</html>`);
-      popupDoc.close();
+      if (htmlRuntimeCloseMonitor) clearTimeout(htmlRuntimeCloseMonitor);
+      htmlRuntimeCloseMonitor = setTimeout(() => {
+        setRunButtonState(false);
+        cleanupHtmlRuntimeSession(runtimeData.runtime_id);
+      }, Math.max(1000, Math.floor((timeoutSeconds + 5) * 1000)));
+      notifyHtmlRuntimePopup({
+        type: 'load',
+        runtime: {
+          runtime_id: runtimeData.runtime_id,
+          view_url: runtimeData.view_url,
+          timeout_seconds: timeoutSeconds,
+          allow_popups: !!runtimeData.allow_popups,
+          title
+        }
+      });
       appendOut('[HTML Runtime] WebView opened.\n');
     }
 
@@ -1135,14 +1121,6 @@ const INPUT_TOKEN = "[[_IDE_INPUT_]]";
       lastRunExceptionEntry = null;
       hideExceptionHelpButton();
       closeExceptionHelpModal();
-      // Save current file before running
-      if (currentOpenFile && (USER_TOKEN || TEACHER_TOKEN || ADMIN_TOKEN)) {
-        try {
-          await saveCurrentFile();
-        } catch (err) {
-          appendOut(`[Warning: could not save "${currentOpenFile.name}" before running: ${err}]\n`);
-        }
-      }
       if (csvEditorActive) {
         appendOut('[Run skipped: CSV files use spreadsheet editing only.]\n');
         return;
@@ -1151,6 +1129,15 @@ const INPUT_TOKEN = "[[_IDE_INPUT_]]";
         if (!currentOpenFile?.path) {
           appendOut('[HTML Runtime] Open an HTML file first.\n');
           return;
+        }
+        if (!openHtmlRuntimePopupShell()) return;
+        setRunButtonState(true);
+        if (currentOpenFile && (USER_TOKEN || TEACHER_TOKEN || ADMIN_TOKEN)) {
+          try {
+            await saveCurrentFile();
+          } catch (err) {
+            appendOut(`[Warning: could not save "${currentOpenFile.name}" before running: ${err}]\n`);
+          }
         }
         try {
           const res = await fetch('/api/html-runtime/start', {
@@ -1161,15 +1148,25 @@ const INPUT_TOKEN = "[[_IDE_INPUT_]]";
           const j = await res.json().catch(() => ({}));
           if (!j?.ok) {
             appendOut(`[HTML Runtime Error] ${j?.error || 'Failed to start HTML runtime'}\n`);
+            notifyHtmlRuntimePopup({ type: 'error', message: j?.error || 'Failed to start HTML runtime' });
+            setRunButtonState(false);
             return;
           }
-          setRunButtonState(true);
           openHtmlRuntimePopup(j);
         } catch (err) {
           appendOut('[HTML Runtime Error] Network error while starting HTML runtime.\n');
+          notifyHtmlRuntimePopup({ type: 'error', message: 'Network error while starting HTML runtime.' });
           setRunButtonState(false);
         }
         return;
+      }
+      // Save current file before running Python or JavaScript.
+      if (currentOpenFile && (USER_TOKEN || TEACHER_TOKEN || ADMIN_TOKEN)) {
+        try {
+          await saveCurrentFile();
+        } catch (err) {
+          appendOut(`[Warning: could not save "${currentOpenFile.name}" before running: ${err}]\n`);
+        }
       }
       appendOut('[Sending code]\n');
       setRunButtonState(true);

--- a/static/js/state-socket.js
+++ b/static/js/state-socket.js
@@ -1036,7 +1036,15 @@ const INPUT_TOKEN = "[[_IDE_INPUT_]]";
       const channel = new BroadcastChannel(`eagle-html-runtime-${channelId}`);
       channel.onmessage = (event) => {
         const payload = event.data || {};
-        if (payload.type === 'eagle-html-runtime-log') {
+        if (payload.type === 'ready') {
+          if (htmlRuntimeWindow) {
+            htmlRuntimeWindow.ready = true;
+            if (htmlRuntimeWindow.pendingRuntime) {
+              htmlRuntimeWindow.channel.postMessage(htmlRuntimeWindow.pendingRuntime);
+              htmlRuntimeWindow.pendingRuntime = null;
+            }
+          }
+        } else if (payload.type === 'eagle-html-runtime-log') {
           appendHtmlRuntimeLog(payload);
         } else if (payload.type === 'closed') {
           const closedRuntimeId = String(payload.runtime_id || '');
@@ -1054,7 +1062,7 @@ const INPUT_TOKEN = "[[_IDE_INPUT_]]";
         setRunButtonState(false);
         return false;
       }
-      htmlRuntimeWindow = { popup, channel, channelId };
+      htmlRuntimeWindow = { popup, channel, channelId, ready: false, pendingRuntime: null };
       appendOut('[HTML Runtime] Preparing WebView...\n');
       return true;
     }
@@ -1075,7 +1083,7 @@ const INPUT_TOKEN = "[[_IDE_INPUT_]]";
         setRunButtonState(false);
         cleanupHtmlRuntimeSession(runtimeData.runtime_id);
       }, Math.max(1000, Math.floor((timeoutSeconds + 5) * 1000)));
-      notifyHtmlRuntimePopup({
+      const loadMessage = {
         type: 'load',
         runtime: {
           runtime_id: runtimeData.runtime_id,
@@ -1084,7 +1092,12 @@ const INPUT_TOKEN = "[[_IDE_INPUT_]]";
           allow_popups: !!runtimeData.allow_popups,
           title
         }
-      });
+      };
+      if (htmlRuntimeWindow?.ready) {
+        notifyHtmlRuntimePopup(loadMessage);
+      } else if (htmlRuntimeWindow) {
+        htmlRuntimeWindow.pendingRuntime = loadMessage;
+      }
       appendOut('[HTML Runtime] WebView opened.\n');
     }
 

--- a/static/js/state-socket.js
+++ b/static/js/state-socket.js
@@ -953,6 +953,29 @@ const INPUT_TOKEN = "[[_IDE_INPUT_]]";
       return lower.endsWith('.html') || lower.endsWith('.htm');
     }
 
+    function makeHtmlRuntimeChannelId() {
+      if (window.crypto?.randomUUID) return window.crypto.randomUUID().replace(/[^A-Za-z0-9_-]/g, '');
+      return `rt${Date.now()}${Math.random().toString(36).slice(2)}`.replace(/[^A-Za-z0-9_-]/g, '');
+    }
+
+    function appendHtmlRuntimeLog(payload) {
+      const lvl = String(payload.level || 'info').toUpperCase();
+      const msg = String(payload.message || '').trim();
+      if (!msg) return;
+      appendOut(`[HTML ${lvl}] ${msg}\n`);
+    }
+
+    function teardownHtmlRuntimeBroadcast() {
+      if (htmlRuntimeCloseMonitor) {
+        clearTimeout(htmlRuntimeCloseMonitor);
+        htmlRuntimeCloseMonitor = null;
+      }
+      try {
+        if (htmlRuntimeWindow?.channel) htmlRuntimeWindow.channel.close();
+      } catch {}
+      if (htmlRuntimeWindow) htmlRuntimeWindow.channel = null;
+    }
+
     async function cleanupHtmlRuntimeSession(runtimeId = htmlRuntimeId) {
       const rid = String(runtimeId || '').trim();
       if (!rid) return;
@@ -966,18 +989,25 @@ const INPUT_TOKEN = "[[_IDE_INPUT_]]";
       if (rid === htmlRuntimeId) htmlRuntimeId = '';
     }
 
-    function closeHtmlRuntimeWindow() {
-      if (htmlRuntimeCloseMonitor) {
-        clearInterval(htmlRuntimeCloseMonitor);
-        htmlRuntimeCloseMonitor = null;
-      }
+    function notifyHtmlRuntimePopup(payload) {
       try {
-        if (htmlRuntimeWindow && !htmlRuntimeWindow.closed) {
+        htmlRuntimeWindow?.channel?.postMessage(payload);
+      } catch {}
+    }
+
+    function closeHtmlRuntimeWindow() {
+      const runtimeId = htmlRuntimeId;
+      notifyHtmlRuntimePopup({ type: 'stop', reason: 'Execution stopped.' });
+      try {
+        if (htmlRuntimeWindow?.popup && !htmlRuntimeWindow.popup.closed) {
+          htmlRuntimeWindow.popup.close();
+        } else if (htmlRuntimeWindow && !htmlRuntimeWindow.closed) {
           htmlRuntimeWindow.close();
         }
       } catch {}
+      teardownHtmlRuntimeBroadcast();
       htmlRuntimeWindow = null;
-      cleanupHtmlRuntimeSession();
+      cleanupHtmlRuntimeSession(runtimeId);
     }
 
     function setRunButtonState(running) {
@@ -996,109 +1026,65 @@ const INPUT_TOKEN = "[[_IDE_INPUT_]]";
       setRunButtonState(false);
     }
 
+    function openHtmlRuntimePopupShell() {
+      closeHtmlRuntimeWindow();
+      if (!('BroadcastChannel' in window)) {
+        appendOut('[HTML Runtime] This browser does not support isolated HTML previews.\n');
+        return false;
+      }
+      const channelId = makeHtmlRuntimeChannelId();
+      const channel = new BroadcastChannel(`eagle-html-runtime-${channelId}`);
+      channel.onmessage = (event) => {
+        const payload = event.data || {};
+        if (payload.type === 'eagle-html-runtime-log') {
+          appendHtmlRuntimeLog(payload);
+        } else if (payload.type === 'closed') {
+          const closedRuntimeId = String(payload.runtime_id || '');
+          if (closedRuntimeId && closedRuntimeId === htmlRuntimeId) cleanupHtmlRuntimeSession(closedRuntimeId);
+          teardownHtmlRuntimeBroadcast();
+          htmlRuntimeWindow = null;
+          setRunButtonState(false);
+        }
+      };
+      htmlRuntimeId = '';
+      const popup = window.open(`/api/html-runtime/popup/${encodeURIComponent(channelId)}`, `eagle-html-runtime-${channelId}`, 'popup=yes,width=1100,height=760');
+      if (!popup) {
+        appendOut('[HTML Runtime] Popup blocked by browser.\n');
+        try { channel.close(); } catch {}
+        setRunButtonState(false);
+        return false;
+      }
+      htmlRuntimeWindow = { popup, channel, channelId };
+      appendOut('[HTML Runtime] Preparing WebView...\n');
+      return true;
+    }
+
     function openHtmlRuntimePopup(runtimeData) {
       if (!runtimeData?.runtime_id || !runtimeData?.view_url) {
         appendOut('[HTML Runtime] Invalid runtime response\n');
+        notifyHtmlRuntimePopup({ type: 'error', message: 'Invalid runtime response.' });
         setRunButtonState(false);
         return;
       }
 
-      closeHtmlRuntimeWindow();
       htmlRuntimeId = runtimeData.runtime_id;
-      const popup = window.open('', `eagle-html-runtime-${runtimeData.runtime_id}`, 'popup=yes,width=1100,height=760');
-      if (!popup) {
-        appendOut('[HTML Runtime] Popup blocked by browser.\n');
-        cleanupHtmlRuntimeSession(runtimeData.runtime_id);
-        setRunButtonState(false);
-        return;
-      }
-      htmlRuntimeWindow = popup;
-      if (htmlRuntimeCloseMonitor) clearInterval(htmlRuntimeCloseMonitor);
-      htmlRuntimeCloseMonitor = setInterval(() => {
-        if (!htmlRuntimeWindow || htmlRuntimeWindow.closed) {
-          clearInterval(htmlRuntimeCloseMonitor);
-          htmlRuntimeCloseMonitor = null;
-          htmlRuntimeWindow = null;
-          cleanupHtmlRuntimeSession();
-          setRunButtonState(false);
-        }
-      }, 400);
-
       const timeoutSeconds = Number(runtimeData.timeout_seconds || 30);
-      const allowPopups = !!runtimeData.allow_popups;
       const title = `HTML WebView • ${currentOpenFile?.name || 'index.html'}`;
-      const iframeSandbox = ['allow-scripts', 'allow-same-origin'];
-      if (allowPopups) iframeSandbox.push('allow-popups');
-      const popupDoc = popup.document;
-      popupDoc.open();
-      popupDoc.write(`<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>${title.replace(/</g, '&lt;')}</title>
-  <style>
-    body{margin:0;font-family:Inter,Arial,sans-serif;background:#121212;color:#eaeaea;display:flex;flex-direction:column;height:100vh}
-    .hdr{display:flex;justify-content:space-between;align-items:center;padding:10px 14px;background:#1f1f1f;border-bottom:1px solid #333}
-    .hdr strong{font-size:14px}
-    .hdr button{border:0;border-radius:8px;padding:6px 10px;background:#c62828;color:#fff;cursor:pointer;font-weight:700}
-    .runtime-msg{font-size:12px;opacity:.85}
-    #runtimeFrame{flex:1;width:100%;border:0;background:#fff}
-  </style>
-</head>
-<body>
-  <div class="hdr">
-    <div><strong>${title.replace(/</g, '&lt;')}</strong><div class="runtime-msg" id="runtimeMsg">Running...</div></div>
-    <button id="runtimeExitBtn">Exit ✕</button>
-  </div>
-  <iframe id="runtimeFrame" sandbox="${iframeSandbox.join(' ')}" src="${runtimeData.view_url}"></iframe>
-  <script>
-    const runtimeId = ${JSON.stringify(runtimeData.runtime_id)};
-    const timeoutMs = ${Math.max(1000, Math.floor(timeoutSeconds * 1000))};
-    let stopped = false;
-    const frame = document.getElementById('runtimeFrame');
-    const msgEl = document.getElementById('runtimeMsg');
-    const sendToOpener = (payload) => { try { window.opener && window.opener.postMessage(payload, '*'); } catch {} };
-    const setMsg = (text) => { if (msgEl) msgEl.textContent = text; };
-    const cleanupRuntime = () => {
-      try {
-        navigator.sendBeacon('/api/html-runtime/cleanup', new Blob([JSON.stringify({ runtime_id: runtimeId })], { type: 'application/json' }));
-      } catch {
-        fetch('/api/html-runtime/cleanup', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ runtime_id: runtimeId }) }).catch(() => {});
-      }
-    };
-    const terminate = (reason) => {
-      if (stopped) return;
-      stopped = true;
-      frame.src = 'about:blank';
-      setMsg(reason || 'Execution stopped.');
-      sendToOpener({ type:'eagle-html-runtime-log', level:'warn', message: reason || 'Execution stopped.' });
-    };
-    document.getElementById('runtimeExitBtn').addEventListener('click', () => window.close());
-    window.addEventListener('beforeunload', cleanupRuntime);
-    const timeoutHandle = setTimeout(() => terminate('Execution time limit reached.'), timeoutMs);
-    window.addEventListener('message', (event) => {
-      const data = event.data || {};
-      if (!data.__eagleHtmlRuntime) return;
-      if (data.type === 'limit') {
-        terminate('Execution time limit reached.');
-      } else if (data.type === 'error') {
-        const details = data.message || 'JavaScript runtime error';
-        sendToOpener({ type:'eagle-html-runtime-log', level:'error', message: details });
-      } else if (data.type === 'console' && data.level === 'error') {
-        sendToOpener({ type:'eagle-html-runtime-log', level:'error', message: data.message || 'console.error' });
-      } else if (data.type === 'status') {
-        sendToOpener({ type:'eagle-html-runtime-log', level:'warn', message: data.message || 'Runtime status' });
-      }
-    });
-    frame.addEventListener('load', () => {
-      if (!stopped) setMsg('Running...');
-    });
-    frame.addEventListener('error', () => terminate('Execution stopped due to iframe load error.'));
-    window.addEventListener('unload', () => clearTimeout(timeoutHandle));
-  <\/script>
-</body>
-</html>`);
-      popupDoc.close();
+      if (htmlRuntimeCloseMonitor) clearTimeout(htmlRuntimeCloseMonitor);
+      htmlRuntimeCloseMonitor = setTimeout(() => {
+        setRunButtonState(false);
+        cleanupHtmlRuntimeSession(runtimeData.runtime_id);
+      }, Math.max(1000, Math.floor((timeoutSeconds + 5) * 1000)));
+      notifyHtmlRuntimePopup({
+        type: 'load',
+        runtime: {
+          runtime_id: runtimeData.runtime_id,
+          view_url: runtimeData.view_url,
+          timeout_seconds: timeoutSeconds,
+          allow_popups: !!runtimeData.allow_popups,
+          title
+        }
+      });
       appendOut('[HTML Runtime] WebView opened.\n');
     }
 
@@ -1135,14 +1121,6 @@ const INPUT_TOKEN = "[[_IDE_INPUT_]]";
       lastRunExceptionEntry = null;
       hideExceptionHelpButton();
       closeExceptionHelpModal();
-      // Save current file before running
-      if (currentOpenFile && (USER_TOKEN || TEACHER_TOKEN || ADMIN_TOKEN)) {
-        try {
-          await saveCurrentFile();
-        } catch (err) {
-          appendOut(`[Warning: could not save "${currentOpenFile.name}" before running: ${err}]\n`);
-        }
-      }
       if (csvEditorActive) {
         appendOut('[Run skipped: CSV files use spreadsheet editing only.]\n');
         return;
@@ -1151,6 +1129,15 @@ const INPUT_TOKEN = "[[_IDE_INPUT_]]";
         if (!currentOpenFile?.path) {
           appendOut('[HTML Runtime] Open an HTML file first.\n');
           return;
+        }
+        if (!openHtmlRuntimePopupShell()) return;
+        setRunButtonState(true);
+        if (currentOpenFile && (USER_TOKEN || TEACHER_TOKEN || ADMIN_TOKEN)) {
+          try {
+            await saveCurrentFile();
+          } catch (err) {
+            appendOut(`[Warning: could not save "${currentOpenFile.name}" before running: ${err}]\n`);
+          }
         }
         try {
           const res = await fetch('/api/html-runtime/start', {
@@ -1161,15 +1148,25 @@ const INPUT_TOKEN = "[[_IDE_INPUT_]]";
           const j = await res.json().catch(() => ({}));
           if (!j?.ok) {
             appendOut(`[HTML Runtime Error] ${j?.error || 'Failed to start HTML runtime'}\n`);
+            notifyHtmlRuntimePopup({ type: 'error', message: j?.error || 'Failed to start HTML runtime' });
+            setRunButtonState(false);
             return;
           }
-          setRunButtonState(true);
           openHtmlRuntimePopup(j);
         } catch (err) {
           appendOut('[HTML Runtime Error] Network error while starting HTML runtime.\n');
+          notifyHtmlRuntimePopup({ type: 'error', message: 'Network error while starting HTML runtime.' });
           setRunButtonState(false);
         }
         return;
+      }
+      // Save current file before running Python or JavaScript.
+      if (currentOpenFile && (USER_TOKEN || TEACHER_TOKEN || ADMIN_TOKEN)) {
+        try {
+          await saveCurrentFile();
+        } catch (err) {
+          appendOut(`[Warning: could not save "${currentOpenFile.name}" before running: ${err}]\n`);
+        }
       }
       appendOut('[Sending code]\n');
       setRunButtonState(true);

--- a/tests/test_html_runtime.py
+++ b/tests/test_html_runtime.py
@@ -1,0 +1,127 @@
+import builtins
+import getpass
+import tempfile
+import unittest
+from pathlib import Path
+
+
+_ORIGINAL_INPUT = builtins.input
+_ORIGINAL_GETPASS = getpass.getpass
+builtins.input = lambda _prompt="": "admin@eagleide.local"
+getpass.getpass = lambda _prompt="": "password"
+
+import app as eagle  # noqa: E402
+
+builtins.input = _ORIGINAL_INPUT
+getpass.getpass = _ORIGINAL_GETPASS
+
+
+class HtmlRuntimeTestCase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.user_files_dir = self.root / "user_files"
+        self.sandbox_dir = self.root / "sandboxes"
+        self.user_files_dir.mkdir()
+        self.sandbox_dir.mkdir()
+
+        self.original_user_files_dir = eagle.USER_FILES_DIR
+        self.original_sandbox_dir = eagle.SANDBOX_DIR
+        eagle.USER_FILES_DIR = self.user_files_dir
+        eagle.SANDBOX_DIR = self.sandbox_dir
+        eagle._html_runtime_sessions.clear()
+
+        self.email = "html.student@example.com"
+        self.token = "student-token"
+        eagle._student_tokens[self.token] = {
+            "email": self.email,
+            "name": "HTML Student",
+            "role": "student",
+            "class_id": None,
+            "class_ids": [],
+        }
+        self.user_dir = eagle._get_user_dir(self.email)
+        self.user_dir.mkdir(parents=True)
+        (self.user_dir / "index.html").write_text(
+            '<!doctype html><html><head><title>Runtime</title><link rel="stylesheet" href="styles.css"></head>'
+            '<body><h1>Runtime OK</h1><script>console.error("boom");</script></body></html>',
+            encoding="utf-8",
+        )
+        (self.user_dir / "styles.css").write_text("h1 { color: red; }\n", encoding="utf-8")
+        (self.user_dir / "large.txt").write_text("x" * 1024, encoding="utf-8")
+
+        self.client = eagle.app.test_client()
+
+    def tearDown(self):
+        eagle._student_tokens.pop(self.token, None)
+        eagle._html_runtime_sessions.clear()
+        eagle.USER_FILES_DIR = self.original_user_files_dir
+        eagle.SANDBOX_DIR = self.original_sandbox_dir
+        self.tmp.cleanup()
+
+    def _start_runtime(self, file_path="index.html"):
+        return self.client.post(
+            "/api/html-runtime/start",
+            headers={"X-User-Token": self.token},
+            json={"file_path": file_path},
+        )
+
+    def test_start_uses_live_user_root_without_copying_workspace(self):
+        response = self._start_runtime()
+
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        self.assertTrue(data["ok"])
+        self.assertIn("/api/html-runtime/view/", data["view_url"])
+        self.assertFalse(list(self.sandbox_dir.glob("html_runtime_*")))
+
+        session = eagle._html_runtime_sessions[data["runtime_id"]]
+        self.assertEqual(Path(session["runtime_root"]), self.user_dir.resolve())
+        self.assertEqual(session["entry_file"], "index.html")
+        self.assertNotIn("runtime_dir", session)
+
+    def test_view_injects_bridge_and_serves_relative_assets(self):
+        start_data = self._start_runtime().get_json()
+
+        html_response = self.client.get(start_data["view_url"])
+        self.assertEqual(html_response.status_code, 200)
+        html = html_response.get_data(as_text=True)
+        self.assertIn("__eagleHtmlRuntime", html)
+        self.assertIn("Runtime OK", html)
+        self.assertIn("Content-Security-Policy", html_response.headers)
+
+        css_response = self.client.get(f"/api/html-runtime/view/{start_data['runtime_id']}/styles.css")
+        self.assertEqual(css_response.status_code, 200)
+        self.assertIn("color: red", css_response.get_data(as_text=True))
+
+    def test_view_rejects_path_traversal(self):
+        start_data = self._start_runtime().get_json()
+        secret = self.root / "secret.html"
+        secret.write_text("<h1>secret</h1>", encoding="utf-8")
+
+        response = self.client.get(f"/api/html-runtime/view/{start_data['runtime_id']}/../secret.html")
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_cleanup_removes_session_without_deleting_user_files(self):
+        start_data = self._start_runtime().get_json()
+        runtime_id = start_data["runtime_id"]
+
+        response = self.client.post("/api/html-runtime/cleanup", json={"runtime_id": runtime_id})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn(runtime_id, eagle._html_runtime_sessions)
+        self.assertTrue((self.user_dir / "index.html").exists())
+
+    def test_popup_shell_is_channel_based_and_cross_opener_isolated(self):
+        response = self.client.get("/api/html-runtime/popup/testchannel")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_data(as_text=True)
+        self.assertIn("BroadcastChannel", body)
+        self.assertIn("sandbox=\"allow-scripts\"", body)
+        self.assertEqual(response.headers.get("Cross-Origin-Opener-Policy"), "same-origin")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Open the HTML runtime popup shell immediately on Run so browser user activation is preserved.
- Replace blocking workspace copy with short-lived validated runtime sessions served from the user workspace.
- Isolate preview communication through a popup shell and BroadcastChannel, with sandboxed iframe loading and cleanup.
- Queue runtime loading until the popup shell reports readiness.
- Add focused unittest coverage for runtime start/view/cleanup and popup shell behavior.

## Tests
- `.venv/bin/python -m py_compile app.py`
- `node --check static/js/app-core.js`
- `node --check static/js/state-socket.js`
- `.venv/bin/python -m unittest discover -s tests -v`
- Manual browser walkthrough: normal HTML renders and mirrors console.error; blocking `while(true)` preview no longer freezes the main IDE.

## Walkthrough
[html_runtime_preview_isolation_walkthrough.mp4](https://cursor.com/agents/bc-b70bf454-1975-5f3f-8a06-125072163efd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhtml_runtime_preview_isolation_walkthrough.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://personalproje-umv9553.slack.com/archives/C0B8SG2FBBM/p1780906735796909?thread_ts=1780906735.796909&cid=C0B8SG2FBBM)

<div><a href="https://cursor.com/agents/bc-b70bf454-1975-5f3f-8a06-125072163efd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b70bf454-1975-5f3f-8a06-125072163efd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

